### PR TITLE
Fix dds_sample_info.publication_handle incorrectly set to 1

### DIFF
--- a/src/core/ddsc/include/ddsc/dds.h
+++ b/src/core/ddsc/include/ddsc/dds.h
@@ -173,8 +173,6 @@ typedef struct dds_sample_info
   uint32_t generation_rank;
   /** difference in generations between the sample and most recent sample of the same instance when read/take was called */
   uint32_t absolute_generation_rank;
-  /** timestamp of a data instance when it is added to a read queue */
-  dds_time_t reception_timestamp; /* NOTE: VLite extension */
 }
 dds_sample_info_t;
 

--- a/src/core/ddsc/src/dds__rhc.h
+++ b/src/core/ddsc/src/dds__rhc.h
@@ -25,8 +25,6 @@ struct rhc;
 struct nn_xqos;
 struct serdata;
 struct tkmap_instance;
-struct tkmap;
-struct nn_rsample_info;
 struct proxy_writer_info;
 
 struct rhc * dds_rhc_new (dds_reader * reader, const struct sertopic * topic);
@@ -37,7 +35,7 @@ uint32_t dds_rhc_lock_samples (struct rhc * rhc);
 
 DDS_EXPORT bool dds_rhc_store
 (
-  struct rhc * __restrict rhc, const struct nn_rsample_info * __restrict sampleinfo,
+  struct rhc * __restrict rhc, const struct proxy_writer_info * __restrict pwr_info,
   struct serdata * __restrict sample, struct tkmap_instance * __restrict tk
 );
 void dds_rhc_unregister_wr (struct rhc * __restrict rhc, const struct proxy_writer_info * __restrict pwr_info);

--- a/src/core/ddsc/src/dds__tkmap.h
+++ b/src/core/ddsc/src/dds__tkmap.h
@@ -38,7 +38,6 @@ void dds_tkmap_instance_ref (_In_ struct tkmap_instance *tk);
 uint64_t dds_tkmap_lookup (_In_ struct tkmap *tkmap, _In_ const struct serdata *serdata);
 _Check_return_ bool dds_tkmap_get_key (_In_ struct tkmap * map, _In_ uint64_t iid, _Out_ void * sample);
 _Check_return_ struct tkmap_instance * dds_tkmap_find(
-        _In_opt_ const struct dds_topic * topic,
         _In_ struct serdata * sd,
         _In_ const bool rd,
         _In_ const bool create);

--- a/src/core/ddsc/src/dds_init.c
+++ b/src/core/ddsc/src/dds_init.c
@@ -263,14 +263,14 @@ void ddsi_plugin_init (void)
 
   /* Register read cache functions */
 
-  ddsi_plugin.rhc_free_fn = dds_rhc_free;
-  ddsi_plugin.rhc_fini_fn = dds_rhc_fini;
-  ddsi_plugin.rhc_store_fn = dds_rhc_store;
-  ddsi_plugin.rhc_unregister_wr_fn = dds_rhc_unregister_wr;
-  ddsi_plugin.rhc_relinquish_ownership_fn = dds_rhc_relinquish_ownership;
-  ddsi_plugin.rhc_set_qos_fn = dds_rhc_set_qos;
-  ddsi_plugin.rhc_lookup_fn = dds_tkmap_lookup_instance_ref;
-  ddsi_plugin.rhc_unref_fn = dds_tkmap_instance_unref;
+  ddsi_plugin.rhc_plugin.rhc_free_fn = dds_rhc_free;
+  ddsi_plugin.rhc_plugin.rhc_fini_fn = dds_rhc_fini;
+  ddsi_plugin.rhc_plugin.rhc_store_fn = dds_rhc_store;
+  ddsi_plugin.rhc_plugin.rhc_unregister_wr_fn = dds_rhc_unregister_wr;
+  ddsi_plugin.rhc_plugin.rhc_relinquish_ownership_fn = dds_rhc_relinquish_ownership;
+  ddsi_plugin.rhc_plugin.rhc_set_qos_fn = dds_rhc_set_qos;
+  ddsi_plugin.rhc_plugin.rhc_lookup_fn = dds_tkmap_lookup_instance_ref;
+  ddsi_plugin.rhc_plugin.rhc_unref_fn = dds_tkmap_instance_unref;
 
   /* Register iid generator */
 

--- a/src/core/ddsc/src/dds_instance.c
+++ b/src/core/ddsc/src/dds_instance.c
@@ -71,7 +71,7 @@ dds_instance_find(
         _In_ const bool create)
 {
     serdata_t sd = serialize_key (gv.serpool, topic->m_stopic, data);
-    struct tkmap_instance * inst = dds_tkmap_find (topic, sd, false, create);
+    struct tkmap_instance * inst = dds_tkmap_find (sd, false, create);
     ddsi_serdata_unref (sd);
     return inst;
 }

--- a/src/core/ddsc/src/dds_key.c
+++ b/src/core/ddsc/src/dds_key.c
@@ -17,6 +17,14 @@
 #include "ddsi/q_bswap.h"
 #include "ddsi/q_md5.h"
 
+#ifndef NDEBUG
+static bool keyhash_is_reset(const dds_key_hash_t *kh)
+{
+  static const char nullhash[sizeof(kh->m_hash)];
+  return kh->m_flags == 0 && memcmp(kh->m_hash, nullhash, sizeof(nullhash)) == 0;
+}
+#endif
+
 void dds_key_md5 (dds_key_hash_t * kh)
 {
   md5_state_t md5st;
@@ -43,8 +51,14 @@ void dds_key_gen
   uint32_t len = 0;
   char * dst;
 
-  assert (desc->m_nkeys);
-  assert (kh->m_hash[0] == 0 && kh->m_hash[15] == 0);
+  assert(keyhash_is_reset(kh));
+
+  if (desc->m_nkeys == 0)
+  {
+    kh->m_flags = DDS_KEY_SET | DDS_KEY_HASH_SET | DDS_KEY_IS_HASH;
+    kh->m_key_len = sizeof (kh->m_hash);
+    return;
+  }
 
   kh->m_flags = DDS_KEY_SET | DDS_KEY_HASH_SET;
 

--- a/src/core/ddsc/src/q_osplser.c
+++ b/src/core/ddsc/src/q_osplser.c
@@ -22,11 +22,7 @@ serdata_t serialize (serstatepool_t pool, const struct sertopic * tp, const void
 {
   dds_stream_t os;
   serstate_t st = ddsi_serstate_new (pool, tp);
-
-  if (tp->nkeys)
-  {
-    dds_key_gen ((const dds_topic_descriptor_t*) tp->type, &st->data->v.keyhash, (char*) sample);
-  }
+  dds_key_gen ((const dds_topic_descriptor_t*) tp->type, &st->data->v.keyhash, (char*) sample);
   dds_stream_from_serstate (&os, st);
   dds_stream_write_sample (&os, sample, tp);
   dds_stream_add_to_serstate (&os, st);
@@ -65,21 +61,14 @@ int serdata_cmp (const struct serdata *a, const struct serdata *b)
 serdata_t serialize_key (serstatepool_t pool, const struct sertopic * tp, const void * sample)
 {
   serdata_t sd;
-  if (tp->nkeys)
-  {
-    dds_stream_t os;
-    dds_topic_descriptor_t * desc = (dds_topic_descriptor_t*) tp->type;
-    serstate_t st = ddsi_serstate_new (pool, tp);
-    dds_key_gen (desc, &st->data->v.keyhash, (char*) sample);
-    dds_stream_from_serstate (&os, st);
-    dds_stream_write_key (&os, sample, desc);
-    dds_stream_add_to_serstate (&os, st);
-    sd = st->data;
-  }
-  else
-  {
-    sd = serialize (pool, tp, sample);
-  }
+  dds_stream_t os;
+  dds_topic_descriptor_t * desc = (dds_topic_descriptor_t*) tp->type;
+  serstate_t st = ddsi_serstate_new (pool, tp);
+  dds_key_gen (desc, &st->data->v.keyhash, (char*) sample);
+  dds_stream_from_serstate (&os, st);
+  dds_stream_write_key (&os, sample, desc);
+  dds_stream_add_to_serstate (&os, st);
+  sd = st->data;
   sd->v.st->kind = STK_KEY;
   return sd;
 }

--- a/src/core/ddsc/tests/reader_iterator.c
+++ b/src/core/ddsc/tests/reader_iterator.c
@@ -63,6 +63,7 @@
 #define MAX_SAMPLES                 21
 
 #define RDR_NOT_READ_CNT            11
+#define RDR_INV_READ_CNT             1
 int rdr_expected_long_2[RDR_NOT_READ_CNT] = { 0, 1, 2, 6, 7, 9, 11, 13, 14, 16, 19 };
 
 /* Because we only read one sample at a time, only the first sample of an instance
@@ -344,13 +345,13 @@ samples_cnt(void)
 /*************************************************************************************************/
 Test(ddsc_read_next, reader, .init=reader_iterator_init, .fini=reader_iterator_fini)
 {
-    dds_return_t cnt = 0;
+    dds_return_t cnt = 0, cntinv = 0;
     dds_return_t ret = 1;
 
     while (ret == 1){
       ret = dds_read_next(g_reader, g_samples, g_info);
       cr_assert_geq(ret, 0 , "# read %d", ret);
-      if(ret == 1){
+      if(ret == 1 && g_info[0].valid_data){
         Space_Type1 *sample = (Space_Type1*)g_samples[0];
         PRINT_SAMPLE("ddsc_read_next::reader: Read", (*sample));
 
@@ -373,10 +374,13 @@ Test(ddsc_read_next, reader, .init=reader_iterator_init, .fini=reader_iterator_f
         cr_assert_eq(g_info[0].view_state,     expected_vst);
         cr_assert_eq(g_info[0].instance_state, expected_ist);
         cnt ++;
+      } else if (ret == 1 && !g_info[0].valid_data) {
+        cntinv ++;
       }
     }
 
     cr_assert_eq(cnt, RDR_NOT_READ_CNT);
+    cr_assert_eq(cntinv, RDR_INV_READ_CNT);
 
     /* All samples should still be available. */
     ret = samples_cnt();
@@ -453,13 +457,13 @@ Theory((void **buf, dds_sample_info_t *si), ddsc_read_next, invalid_buffers, .in
 /*************************************************************************************************/
 Test(ddsc_read_next_wl, reader, .init=reader_iterator_init, .fini=reader_iterator_fini)
 {
-    dds_return_t cnt = 0;
+    dds_return_t cnt = 0, cntinv = 0;
     dds_return_t ret = 1;
 
     while (ret == 1){
       ret = dds_read_next_wl(g_reader, g_loans, g_info);
       cr_assert_geq(ret, 0 , "# read %d", ret);
-      if(ret == 1){
+      if(ret == 1 && g_info[0].valid_data){
         Space_Type1 *sample = (Space_Type1*)g_loans[0];
         PRINT_SAMPLE("ddsc_read_next_wl::reader: Read", (*sample));
 
@@ -482,10 +486,13 @@ Test(ddsc_read_next_wl, reader, .init=reader_iterator_init, .fini=reader_iterato
         cr_assert_eq(g_info[0].view_state,     expected_vst);
         cr_assert_eq(g_info[0].instance_state, expected_ist);
         cnt ++;
+      } else if (ret == 1 && !g_info[0].valid_data) {
+        cntinv ++;
       }
     }
 
     cr_assert_eq(cnt, RDR_NOT_READ_CNT);
+    cr_assert_eq(cntinv, RDR_INV_READ_CNT);
 
     ret = dds_return_loan(g_reader, g_loans, ret);
     cr_assert_eq (ret, DDS_RETCODE_OK);
@@ -564,13 +571,13 @@ Theory((void **buf, dds_sample_info_t *si), ddsc_read_next_wl, invalid_buffers, 
 /*************************************************************************************************/
 Test(ddsc_take_next, reader, .init=reader_iterator_init, .fini=reader_iterator_fini)
 {
-    dds_return_t cnt = 0;
+    dds_return_t cnt = 0, cntinv = 0;
     dds_return_t ret = 1;
 
     while (ret == 1){
       ret = dds_take_next(g_reader, g_samples, g_info);
       cr_assert_geq(ret, 0 , "# read %d", ret);
-      if(ret == 1){
+      if(ret == 1 && g_info[0].valid_data){
         Space_Type1 *sample = (Space_Type1*)g_samples[0];
         PRINT_SAMPLE("ddsc_take_next::reader: Read", (*sample));
 
@@ -593,10 +600,13 @@ Test(ddsc_take_next, reader, .init=reader_iterator_init, .fini=reader_iterator_f
         cr_assert_eq(g_info[0].view_state,     expected_vst);
         cr_assert_eq(g_info[0].instance_state, expected_ist);
         cnt ++;
+      } else if (ret == 1 && !g_info[0].valid_data) {
+        cntinv ++;
       }
     }
 
     cr_assert_eq(cnt, RDR_NOT_READ_CNT);
+    cr_assert_eq(cntinv, RDR_INV_READ_CNT);
 
     /* All samples should still be available. */
     ret = samples_cnt();
@@ -671,13 +681,13 @@ Theory((void **buf, dds_sample_info_t *si), ddsc_take_next, invalid_buffers, .in
 /*************************************************************************************************/
 Test(ddsc_take_next_wl, reader, .init=reader_iterator_init, .fini=reader_iterator_fini)
 {
-    dds_return_t cnt = 0;
+    dds_return_t cnt = 0, cntinv = 0;
     dds_return_t ret = 1;
 
     while (ret == 1){
       ret = dds_take_next_wl(g_reader, g_loans, g_info);
       cr_assert_geq(ret, 0 , "# read %d", ret);
-      if(ret == 1){
+      if(ret == 1 && g_info[0].valid_data){
         Space_Type1 *sample = (Space_Type1*)g_loans[0];
         PRINT_SAMPLE("ddsc_read_next_wl::reader: Read", (*sample));
 
@@ -700,10 +710,13 @@ Test(ddsc_take_next_wl, reader, .init=reader_iterator_init, .fini=reader_iterato
         cr_assert_eq(g_info[0].view_state,     expected_vst);
         cr_assert_eq(g_info[0].instance_state, expected_ist);
         cnt ++;
+      } else if (ret == 1 && !g_info[0].valid_data) {
+        cntinv ++;
       }
     }
 
     cr_assert_eq(cnt, RDR_NOT_READ_CNT);
+    cr_assert_eq(cntinv, RDR_INV_READ_CNT);
 
     ret = dds_return_loan(g_reader, g_loans, ret);
     cr_assert_eq (ret, DDS_RETCODE_OK);

--- a/src/core/ddsi/CMakeLists.txt
+++ b/src/core/ddsi/CMakeLists.txt
@@ -18,6 +18,7 @@ PREPEND(srcs_ddsi "${CMAKE_CURRENT_LIST_DIR}/src"
     ddsi_raweth.c
     ddsi_ipaddr.c
     ddsi_mcgroup.c
+    ddsi_rhc_plugin.c
     q_addrset.c
     q_bitset_inlines.c
     q_bswap.c
@@ -67,6 +68,7 @@ PREPEND(hdrs_private_ddsi "${CMAKE_CURRENT_LIST_DIR}/include/ddsi"
     ddsi_raweth.h
     ddsi_ipaddr.h
     ddsi_mcgroup.h
+    ddsi_rhc_plugin.h
     probes-constants.h
     q_addrset.h
     q_align.h

--- a/src/core/ddsi/include/ddsi/ddsi_rhc_plugin.h
+++ b/src/core/ddsi/include/ddsi/ddsi_rhc_plugin.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#ifndef DDSI_RHC_PLUGIN_H
+#define DDSI_RHC_PLUGIN_H
+
+struct rhc;
+struct nn_xqos;
+struct tkmap_instance;
+struct serdata;
+struct sertopic;
+struct entity_common;
+
+struct proxy_writer_info
+{
+  nn_guid_t guid;
+  bool auto_dispose;
+  int32_t ownership_strength;
+  uint64_t iid;
+};
+
+struct ddsi_rhc_plugin
+{
+  void (*rhc_free_fn) (struct rhc *rhc);
+  void (*rhc_fini_fn) (struct rhc *rhc);
+  bool (*rhc_store_fn)
+  (struct rhc * __restrict rhc, const struct proxy_writer_info * __restrict pwr_info,
+   struct serdata * __restrict sample, struct tkmap_instance * __restrict tk);
+  void (*rhc_unregister_wr_fn)
+  (struct rhc * __restrict rhc, const struct proxy_writer_info * __restrict pwr_info);
+  void (*rhc_relinquish_ownership_fn)
+  (struct rhc * __restrict rhc, const uint64_t wr_iid);
+  void (*rhc_set_qos_fn) (struct rhc * rhc, const struct nn_xqos * qos);
+  struct tkmap_instance * (*rhc_lookup_fn) (struct serdata *serdata);
+  void (*rhc_unref_fn) (struct tkmap_instance *tk);
+};
+
+void make_proxy_writer_info(struct proxy_writer_info *pwr_info, const struct entity_common *e, const struct nn_xqos *xqos);
+
+#endif

--- a/src/core/ddsi/include/ddsi/ddsi_ser.h
+++ b/src/core/ddsi/include/ddsi/ddsi_ser.h
@@ -100,7 +100,7 @@ struct serdata_base
   serstate_t st;        /* back pointer to (opaque) serstate so RTPS impl only needs serdata */
   struct serdata_msginfo msginfo;
   int hash_valid;       /* whether hash is valid or must be computed from key/data */
-  uint32_t hash;       /* cached serdata hash, valid only if hash_valid != 0 */
+  uint32_t hash;        /* cached serdata hash, valid only if hash_valid != 0 */
   dds_key_hash_t keyhash;
   bool bswap;           /* Whether state is native endian or requires swapping */
 };

--- a/src/core/ddsi/include/ddsi/q_config.h
+++ b/src/core/ddsi/include/ddsi/q_config.h
@@ -22,6 +22,7 @@
 #include "ddsi/q_xqos.h"
 #include "ddsi/ddsi_tran.h"
 #include "ddsi/q_feature_check.h"
+#include "ddsi/ddsi_rhc_plugin.h"
 
 #if defined (__cplusplus)
 extern "C" {
@@ -404,35 +405,13 @@ struct config
   q__schedPrioClass watchdog_sched_priority_class;
 };
 
-struct rhc;
-struct nn_xqos;
-struct tkmap_instance;
-struct nn_rsample_info;
-struct serdata;
-struct sertopic;
-struct proxy_writer;
-struct proxy_writer_info;
-
 struct ddsi_plugin
 {
   int (*init_fn) (void);
   void (*fini_fn) (void);
 
-
   /* Read cache */
-
-  void (*rhc_free_fn) (struct rhc *rhc);
-  void (*rhc_fini_fn) (struct rhc *rhc);
-  bool (*rhc_store_fn)
-    (struct rhc * __restrict rhc, const struct nn_rsample_info * __restrict sampleinfo,
-     struct serdata * __restrict sample, struct tkmap_instance * __restrict tk);
-  void (*rhc_unregister_wr_fn)
-    (struct rhc * __restrict rhc, const struct proxy_writer_info * __restrict pwr_info);
-  void (*rhc_relinquish_ownership_fn)
-    (struct rhc * __restrict rhc, const uint64_t wr_iid);
-  void (*rhc_set_qos_fn) (struct rhc * rhc, const struct nn_xqos * qos);
-  struct tkmap_instance * (*rhc_lookup_fn) (struct serdata *serdata);
-  void (*rhc_unref_fn) (struct tkmap_instance *tk);
+  struct ddsi_rhc_plugin rhc_plugin;
 
   /* IID generator */
 

--- a/src/core/ddsi/include/ddsi/q_radmin.h
+++ b/src/core/ddsi/include/ddsi/q_radmin.h
@@ -109,14 +109,6 @@ struct receiver_state {
   nn_locator_t srcloc;
 };
 
-struct proxy_writer_info
-{
-  nn_guid_t guid;
-  bool auto_dispose;
-  int32_t ownership_strength;
-  uint64_t iid;
-};
-
 struct nn_rsample_info {
   seqno_t seq;
   struct receiver_state *rst;
@@ -129,9 +121,6 @@ struct nn_rsample_info {
   unsigned pt_wr_info_zoff: 16; /* PrismTech writer info offset */
   unsigned bswap: 1;            /* so we can extract well formatted writer info quicker */
   unsigned complex_qos: 1;      /* includes QoS other than keyhash, 2-bit statusinfo, PT writer info */
-  unsigned hashash: 1;          /* Do we have a key hash */
-  nn_keyhash_t keyhash;         /* Key hash. Not currently used by OSPL */
-  struct proxy_writer_info pwr_info;
 };
 
 struct nn_rdata {

--- a/src/core/ddsi/src/ddsi_rhc_plugin.c
+++ b/src/core/ddsi/src/ddsi_rhc_plugin.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright(c) 2006 to 2018 ADLINK Technology Limited and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+#include "ddsi/q_entity.h"
+#include "ddsi/q_xqos.h"
+#include "ddsi/ddsi_rhc_plugin.h"
+
+void make_proxy_writer_info(struct proxy_writer_info *pwr_info, const struct entity_common *e, const struct nn_xqos *xqos)
+{
+  pwr_info->guid = e->guid;
+  pwr_info->ownership_strength = xqos->ownership_strength.value;
+  pwr_info->auto_dispose = xqos->writer_data_lifecycle.autodispose_unregistered_instances;
+  pwr_info->iid = e->iid;
+}

--- a/src/core/ddsi/src/q_plist.c
+++ b/src/core/ddsi/src/q_plist.c
@@ -3123,16 +3123,6 @@ unsigned char *nn_plist_quickscan (struct nn_rsample_info *dest, const struct nn
     {
       case PID_PAD:
         break;
-      case PID_KEYHASH:
-      if (length < sizeof (dest->keyhash))
-      {
-        TRACE (("plist(vendor %u.%u): quickscan(PID_KEYHASH): buffer too small\n",
-          src->vendorid.id[0], src->vendorid.id[1]));
-        return NULL;
-      }
-      memcpy (&dest->keyhash, pl, sizeof (dest->keyhash));
-      dest->hashash = 1;
-        break;
       case PID_STATUSINFO:
         if (length < 4)
         {

--- a/src/core/ddsi/src/q_transmit.c
+++ b/src/core/ddsi/src/q_transmit.c
@@ -1138,9 +1138,9 @@ int write_sample_gc_notk (struct nn_xpack *xp, struct writer *wr, serdata_t serd
 {
   struct tkmap_instance *tk;
   int res;
-  tk = (ddsi_plugin.rhc_lookup_fn) (serdata);
+  tk = (ddsi_plugin.rhc_plugin.rhc_lookup_fn) (serdata);
   res = write_sample_eot (xp, wr, NULL, serdata, tk, 0, 1);
-  (ddsi_plugin.rhc_unref_fn) (tk);
+  (ddsi_plugin.rhc_plugin.rhc_unref_fn) (tk);
   return res;
 }
 
@@ -1148,9 +1148,9 @@ int write_sample_nogc_notk (struct nn_xpack *xp, struct writer *wr, serdata_t se
 {
   struct tkmap_instance *tk;
   int res;
-  tk = (ddsi_plugin.rhc_lookup_fn) (serdata);
+  tk = (ddsi_plugin.rhc_plugin.rhc_lookup_fn) (serdata);
   res = write_sample_eot (xp, wr, NULL, serdata, tk, 0, 0);
-  (ddsi_plugin.rhc_unref_fn) (tk);
+  (ddsi_plugin.rhc_plugin.rhc_unref_fn) (tk);
   return res;
 }
 

--- a/src/core/ddsi/src/q_xevent.c
+++ b/src/core/ddsi/src/q_xevent.c
@@ -1131,9 +1131,9 @@ static void write_pmd_message (struct nn_xpack *xp, struct participant *pp, unsi
      encoding. */
   serdata->hdr.identifier = PLATFORM_IS_LITTLE_ENDIAN ? CDR_LE : CDR_BE;
 
-  tk = (ddsi_plugin.rhc_lookup_fn) (serdata);
+  tk = (ddsi_plugin.rhc_plugin.rhc_lookup_fn) (serdata);
   write_sample_nogc (xp, wr, serdata, tk);
-  (ddsi_plugin.rhc_unref_fn) (tk);
+  (ddsi_plugin.rhc_plugin.rhc_unref_fn) (tk);
 #undef PMD_DATA_LENGTH
 }
 

--- a/src/tools/pubsub/pubsub.c
+++ b/src/tools/pubsub/pubsub.c
@@ -52,11 +52,10 @@ enum readermode { MODE_PRINT, MODE_CHECK, MODE_ZEROLOAD, MODE_DUMP, MODE_NONE };
 #define PM_IHANDLE 8u
 #define PM_PHANDLE 16u
 #define PM_STIME 32u
-#define PM_RTIME 64u
-#define PM_DGEN 128u
-#define PM_NWGEN 256u
-#define PM_RANKS 512u
-#define PM_STATE 1024u
+#define PM_DGEN 64u
+#define PM_NWGEN 128u
+#define PM_RANKS 256u
+#define PM_STATE 512u
 
 static volatile sig_atomic_t termflag = 0;
 static int pid;
@@ -818,8 +817,6 @@ static void print_sampleinfo(dds_time_t *tstart, dds_time_t tnow, const dds_samp
     sep = " : ";
     if (print_metadata & PM_STIME)
         n += printf ("%s%lld.%09lld", n > 0 ? sep : "", (si->source_timestamp/DDS_NSECS_IN_SEC), (si->source_timestamp%DDS_NSECS_IN_SEC)), sep = " ";
-    if (print_metadata & PM_RTIME)
-        n += printf ("%s%lld.%09lld", n > 0 ? sep : "", (si->reception_timestamp/DDS_NSECS_IN_SEC), (si->reception_timestamp%DDS_NSECS_IN_SEC));
     sep = " : ";
     if (print_metadata & PM_DGEN)
         n += printf ("%s%"PRIu32, n > 0 ? sep : "", si->disposed_generation_count), sep = " ";
@@ -2102,7 +2099,6 @@ static void set_print_mode(const char *optarg) {
                     { "phandle", PM_PHANDLE },
                     { "ihandle", PM_IHANDLE },
                     { "stime", PM_STIME },
-                    { "rtime", PM_RTIME },
                     { "dgen", PM_DGEN },
                     { "nwgen", PM_NWGEN },
                     { "ranks", PM_RANKS },


### PR DESCRIPTION
Fix dds_sample_info.publication_handle incorrectly set to 1 as well as some corner cases where it ended up at 0 and some related assertion failures (#8). Key hash handling got cleaned up in the process.