### PR TITLE
Add support for automated builds using Travis CI and AppVeyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,74 @@
+language: c
+
+# Platform descriptions
+# NOTE: These can be used in creating the build matrix by making use of the
+#       anchor/alias YAML features.
+linux_gcc8: &linux_gcc8
+  os: linux
+  compiler: gcc
+  addons:
+    apt:
+      update: true
+      sources: [ ubuntu-toolchain-r-test ]
+      packages: [ gcc-8 g++-8 oracle-java8-set-default maven ]
+
+linux_clang60: &linux_clang60
+  os: linux
+  compiler: clang
+  addons:
+    apt:
+      update: true
+      sources: [ llvm-toolchain-trusty-6.0, ubuntu-toolchain-r-test ]
+      packages: [ clang-6.0 oracle-java8-set-default maven ]
+
+osx_xcode94: &osx_xcode94
+  os: osx
+  osx_image: xcode94
+  compiler: clang
+
+
+matrix:
+  include:
+    - <<: *linux_gcc8
+      env: [ BUILD_TYPE=Debug, C_COMPILER=gcc-8, CXX_COMPILER=g++-8 ]
+    - <<: *linux_gcc8
+      env: [ BUILD_TYPE=Release, C_COMPILER=gcc-8, CXX_COMPILER=g++-8 ]
+    - <<: *linux_clang60
+      env: [ BUILD_TYPE=Debug, C_COMPILER=clang-6.0, CXX_COMPILER=clang++-6.0 ]
+    - <<: *linux_clang60
+      env: [ BUILT_TYPE=Release, C_COMPILER=clang-6.0, CXX_COMPILER=clang++-6.0 ]
+    - <<: *osx_xcode94
+      env: [ BUILD_TYPE=Debug, C_COMPILER=clang, CXX_COMPILER=clang++ ]
+    - <<: *osx_xcode94
+      env: [ BUILD_TYPE=Release, C_COMPILER=clang, CXX_COMPILER=clang++ ]
+
+
+before_install:
+  - eval "export CC=${C_COMPILER}";
+  - eval "export CXX=${CXX_COMPILER}";
+
+install:
+  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
+      brew install pyenv-virtualenv;
+      eval "$(pyenv init -)";
+      pyenv virtualenv conan;
+      pyenv rehash;
+      pyenv activate conan;
+      pip install conan --upgrade;
+    else
+      pip install conan --upgrade --user;
+    fi
+  - conan user
+
+before_script:
+  - conan remote add atolab https://api.bintray.com/conan/atolab/public-conan
+  - conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan
+
+script:
+  - mkdir build
+  - cd build
+  - conan install ..
+  - cmake -DBUILD_TESTING=on -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ../src
+  - cmake --build .
+  - ctest -T test
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,45 @@
+# FIXME: Add ARM at some point in the future.
+platform:
+  - x86
+  - x64
+
+configuration:
+  - Debug
+  - Release
+
+matrix:
+  fast_finish: true
+
+environment:
+  PYTHON: "C:\\Python27"
+
+  matrix:
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      GENERATOR: Visual Studio 14 2015
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      GENERATOR: Visual Studio 15 2017
+
+init:
+  - set PATH=%PATH%;%PYTHON%/Scripts/
+  - set ARCH=x86
+  - if %PLATFORM%==x64 (set GENERATOR=%GENERATOR% Win64)
+  - if %PLATFORM%==x64 (set ARCH=x86_64)
+
+install:
+  - pip.exe install conan --upgrade
+  - conan user # Creates the conan data directory
+
+before_build:
+  - conan remote add atolab https://api.bintray.com/conan/atolab/public-conan
+  - conan remote add bincrafters https://api.bintray.com/conan/bincrafters/public-conan
+
+build_script:
+  - mkdir build
+  - cd build
+  - conan install -s arch=%ARCH% -s build_type=%CONFIGURATION% ..
+  - cmake -DBUILD_TESTING=on -DCMAKE_BUILD_TYPE=%CONFIGURATION% -G "%GENERATOR%" ../src
+  - cmake --build .
+
+test_script:
+  - ctest --test-action test --build-config %CONFIGURATION%
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,7 +38,7 @@ build_script:
   - cd build
   - conan install -s arch=%ARCH% -s build_type=%CONFIGURATION% ..
   - cmake -DBUILD_TESTING=on -DCMAKE_BUILD_TYPE=%CONFIGURATION% -G "%GENERATOR%" ../src
-  - cmake --build .
+  - cmake --build . --config %CONFIGURATION%
 
 test_script:
   - ctest --test-action test --build-config %CONFIGURATION%

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,0 +1,6 @@
+[requires]
+cunit/2.1-3@atolab/stable
+criterion/2.3.2@atolab/stable
+
+[generators]
+cmake

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,6 +51,32 @@ if(${CMAKE_C_COMPILER_ID} STREQUAL "SunPro")
   set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_LINKER_FLAGS} -m64")
 endif()
 
+# Conan
+if(EXISTS "${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
+  include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+  if(APPLE)
+    # By default Conan strips all RPATHs (see conanbuildinfo.cmake), which
+    # causes tests to fail as the executables cannot find the library target.
+    # By setting KEEP_RPATHS, Conan does not set CMAKE_SKIP_RPATH and the
+    # resulting binaries still have the RPATH information. This is fine because
+    # CMake will strip the build RPATH information in the install step.
+    #
+    # NOTE:
+    # Conan's default approach is to use the "imports" feature, which copies
+    # all the dependencies into the bin directory. Of course, this doesn't work
+    # quite that well for libraries generated in this Project (see Conan
+    # documentation).
+    #
+    # See the links below for more information.
+    # https://github.com/conan-io/conan/issues/337
+    # https://docs.conan.io/en/latest/howtos/manage_shared_libraries/rpaths.html
+    # https://gitlab.kitware.com/cmake/community/wikis/doc/cmake/RPATH-handling
+    conan_basic_setup(KEEP_RPATHS)
+  else()
+    conan_basic_setup()
+  endif()
+endif()
+
 include(FileIDs)
 include(GNUInstallDirs)
 include(AnalyzeBuild)

--- a/src/cmake/modules/CUnit.cmake
+++ b/src/cmake/modules/CUnit.cmake
@@ -122,6 +122,7 @@ function(add_cunit_executable target)
     add_test(
       NAME "CUnit_${suite}_${test}"
       COMMAND ${target} -a -r "${suite}-${test}" -s ${suite} -t ${test})
+    set_tests_properties("CUnit_${suite}_${test}" PROPERTIES TIMEOUT 10)
     if(APPLE)
       set_property(
         TEST "CUnit_${suite}_${test}"

--- a/src/cmake/modules/CUnit.cmake
+++ b/src/cmake/modules/CUnit.cmake
@@ -124,5 +124,10 @@ function(add_cunit_executable target)
   add_executable(${target} "${runner}.c" "${root}/src/runner.c" ${sources})
   target_link_libraries(${target} CUnit)
   target_include_directories(${target} PRIVATE "${root}/include")
+  if("2.1.3" VERSION_LESS_EQUAL
+       "${CUNIT_VERSION_MAJOR}.${CUNIT_VERSION_MINOR}.${CUNIT_VERSION_PATCH}")
+    set_source_files_properties(
+      "${root}/src/runner.c" PROPERTIES COMPILE_DEFINITIONS HAVE_ENABLE_JUNIT_XML)
+  endif()
 endfunction()
 

--- a/src/cmake/modules/CUnit/src/runner.c
+++ b/src/cmake/modules/CUnit/src/runner.c
@@ -195,7 +195,9 @@ cu_runner_run(
         }
 
         if (runner.junit) {
+#if defined(HAVE_ENABLE_JUNIT_XML)
             CU_automated_enable_junit_xml(CU_TRUE);
+#endif
         } else {
             CU_list_tests_to_file();
         }

--- a/src/cmake/modules/Criterion.cmake
+++ b/src/cmake/modules/Criterion.cmake
@@ -80,6 +80,7 @@ function(add_criterion_executable _target)
     add_test(
       NAME "Criterion_${_suite}_${_name}"
       COMMAND ${_target} --suite ${_suite} --test ${_name} --cunit=${_suite}-${_name} --quiet)
+    set_tests_properties("Criterion_${_suite}_${_name}" PROPERTIES TIMEOUT 10)
     if(APPLE)
       set_property(
         TEST "Criterion_${_suite}_${_name}"

--- a/src/cmake/modules/Criterion.cmake
+++ b/src/cmake/modules/Criterion.cmake
@@ -79,7 +79,7 @@ function(add_criterion_executable _target)
 
     add_test(
       NAME "Criterion_${_suite}_${_name}"
-      COMMAND ${_target} --suite ${_suite} --test ${_name} --cunit=${_suite}-${_name} --quiet)
+      COMMAND ${_target} -j1 --suite ${_suite} --test ${_name} --cunit=${_suite}-${_name} --quiet)
     set_tests_properties("Criterion_${_suite}_${_name}" PROPERTIES TIMEOUT 10)
     if(APPLE)
       set_property(

--- a/src/cmake/modules/Criterion.cmake
+++ b/src/cmake/modules/Criterion.cmake
@@ -16,6 +16,13 @@ include(Glob)
 set(_criterion_dir "${CMAKE_CURRENT_LIST_DIR}/Criterion")
 
 function(add_criterion_executable _target)
+  # Retrieve location of shared libary, which is need to extend the PATH
+  # environment variable on Microsoft Windows, so that the operating
+  # system can locate the .dll that it was linked against.
+  get_target_property(CRITERION_LIBRARY_TYPE Criterion TYPE)
+  get_target_property(CRITERION_IMPORTED_LOCATION Criterion IMPORTED_LOCATION)
+  get_filename_component(CRITERION_LIBRARY_DIR "${CRITERION_IMPORTED_LOCATION}" PATH)
+
   set(s "[ \t\r\n]") # space
   set(w "[0-9a-zA-Z_]") # word
   set(b "[^0-9a-zA-Z_]") # boundary
@@ -73,6 +80,16 @@ function(add_criterion_executable _target)
     add_test(
       NAME "Criterion_${_suite}_${_name}"
       COMMAND ${_target} --suite ${_suite} --test ${_name} --cunit=${_suite}-${_name} --quiet)
+    if(APPLE)
+      set_property(
+        TEST "Criterion_${_suite}_${_name}"
+        PROPERTY ENVIRONMENT "DYLD_LIBRARY_PATH=${CRITERION_LIBRARY_DIR}:$ENV{DYLD_LIBRARY_PATH}")
+    endif()
+    if(WIN32 AND ${CRITERION_LIBRARY_TYPE} STREQUAL "SHARED_LIBRARY")
+      set_property(
+        TEST "Criterion_${_suite}_${_name}"
+        PROPERTY ENVIRONMENT "PATH=${CRITERION_LIBRARY_DIR};$ENV{PATH}")
+    endif()
   endforeach()
 endfunction()
 

--- a/src/cmake/modules/FindCUnit.cmake
+++ b/src/cmake/modules/FindCUnit.cmake
@@ -12,8 +12,23 @@
 find_path(CUNIT_INC CUnit/CUnit.h)
 find_library(CUNIT_LIB cunit)
 
+if(CUNIT_INC AND EXISTS "${CUNIT_INC}/CUnit/CUnit.h")
+  set(PATTERN "^#define CU_VERSION \"([0-9]+)\.([0-9]+)\-([0-9]+)\"$")
+  file(STRINGS "${CUNIT_INC}/CUnit/CUnit.h" CUNIT_H REGEX "${PATTERN}")
+
+  string(REGEX REPLACE "${PATTERN}" "\\1" CUNIT_VERSION_MAJOR "${CUNIT_H}")
+  string(REGEX REPLACE "${PATTERN}" "\\2" CUNIT_VERSION_MINOR "${CUNIT_H}")
+  string(REGEX REPLACE "${PATTERN}" "\\3" CUNIT_VERSION_PATCH "${CUNIT_H}")
+
+  set(CUNIT_VERSION "${CUNIT_VERSION_MAJOR}.${CUNIT_VERSION_MINOR}-${CUNIT_VERSION_PATCH}")
+endif()
+
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(CUnit DEFAULT_MSG CUNIT_LIB CUNIT_INC)
+find_package_handle_standard_args(
+  CUnit
+  REQUIRED_VARS
+    CUNIT_LIB CUNIT_INC
+  VERSION_VAR CUNIT_VERSION)
 
 if(CUNIT_FOUND AND NOT TARGET CUnit)
   add_library(CUnit INTERFACE IMPORTED)

--- a/src/cmake/modules/FindCUnit.cmake
+++ b/src/cmake/modules/FindCUnit.cmake
@@ -9,12 +9,14 @@
 #
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
-find_path(CUNIT_INC CUnit/CUnit.h)
-find_library(CUNIT_LIB cunit)
+set(CUNIT_HEADER "CUnit/CUnit.h")
 
-if(CUNIT_INC AND EXISTS "${CUNIT_INC}/CUnit/CUnit.h")
-  set(PATTERN "^#define CU_VERSION \"([0-9]+)\.([0-9]+)\-([0-9]+)\"$")
-  file(STRINGS "${CUNIT_INC}/CUnit/CUnit.h" CUNIT_H REGEX "${PATTERN}")
+find_path(CUNIT_INCLUDE_DIR ${CUNIT_HEADER})
+mark_as_advanced(CUNIT_INCLUDE_DIR)
+
+if(CUNIT_INCLUDE_DIR AND EXISTS "${CUNIT_INCLUDE_DIR}/${CUNIT_HEADER}")
+  set(PATTERN "^#define CU_VERSION \"([0-9]+)\\.([0-9]+)\\-([0-9]+)\"$")
+  file(STRINGS "${CUNIT_INCLUDE_DIR}/${CUNIT_HEADER}" CUNIT_H REGEX "${PATTERN}")
 
   string(REGEX REPLACE "${PATTERN}" "\\1" CUNIT_VERSION_MAJOR "${CUNIT_H}")
   string(REGEX REPLACE "${PATTERN}" "\\2" CUNIT_VERSION_MINOR "${CUNIT_H}")
@@ -23,16 +25,57 @@ if(CUNIT_INC AND EXISTS "${CUNIT_INC}/CUnit/CUnit.h")
   set(CUNIT_VERSION "${CUNIT_VERSION_MAJOR}.${CUNIT_VERSION_MINOR}-${CUNIT_VERSION_PATCH}")
 endif()
 
+find_library(CUNIT_LIBRARY cunit)
+
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
   CUnit
   REQUIRED_VARS
-    CUNIT_LIB CUNIT_INC
-  VERSION_VAR CUNIT_VERSION)
+    CUNIT_LIBRARY CUNIT_INCLUDE_DIR
+  VERSION_VAR
+    CUNIT_VERSION)
 
-if(CUNIT_FOUND AND NOT TARGET CUnit)
-  add_library(CUnit INTERFACE IMPORTED)
+if(CUNIT_FOUND)
+  set(CUNIT_INCLUDE_DIRS ${CUNIT_INCLUDE_DIR})
+  set(CUNIT_LIBRARIES ${CUNIT_LIBRARY})
 
-  set_property(TARGET CUnit PROPERTY INTERFACE_LINK_LIBRARIES "${CUNIT_LIB}")
-  set_property(TARGET CUnit PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${CUNIT_INC}")
+  if(WIN32)
+    get_filename_component(CUNIT_LIBRARY_DIR "${CUNIT_LIBRARY}}" PATH)
+    get_filename_component(CUNIT_BASENAME "${CUNIT_LIBRARY}}" NAME_WE)
+    get_filename_component(CUNIT_PREFIX "${CUNIT_LIBRARY_DIR}" PATH)
+
+    find_program(
+      CUNIT_DLL
+        "${CMAKE_SHARED_LIBRARY_PREFIX}${CUNIT_BASENAME}${CMAKE_SHARED_LIBRARY_SUFFIX}"
+      HINTS
+        ${CUNIT_PREFIX}
+      PATH_SUFFIXES
+        bin
+      NO_DEFAULT_PATH)
+    mark_as_advanced(CUNIT_DLL)
+
+    # IMPORTANT:
+    # Providing a .dll file as the value for IMPORTED_LOCATION can only be
+    # done for "SHARED" libraries, otherwise the location of the .dll will be
+    # passed to linker, causing it to fail.
+    if(CUNIT_DLL)
+      add_library(CUnit SHARED IMPORTED)
+      set_target_properties(
+        CUnit PROPERTIES IMPORTED_IMPLIB "${CUNIT_LIBRARY}")
+      set_target_properties(
+        CUnit PROPERTIES IMPORTED_LOCATION "${CUNIT_DLL}")
+    else()
+      add_library(CUnit STATIC IMPORTED)
+      set_target_properties(
+        CUnit PROPERTIES IMPORTED_LOCATION "${CUNIT_LIBRARY}")
+    endif()
+  else()
+    add_library(CUnit UNKNOWN IMPORTED)
+    set_target_properties(
+      CUnit PROPERTIES IMPORTED_LOCATION "${CUNIT_LIBRARY}")
+  endif()
+
+  set_target_properties(
+    CUnit PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${CUNIT_INCLUDE_DIR}")
 endif()
+

--- a/src/cmake/modules/FindCriterion.cmake
+++ b/src/cmake/modules/FindCriterion.cmake
@@ -9,16 +9,53 @@
 #
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 #
-find_path(CRITERION_INC criterion/criterion.h PATH_SUFFIXES criterion)
-find_library(CRITERION_LIB criterion)
+find_path(CRITERION_INCLUDE_DIR criterion/criterion.h)
+find_library(CRITERION_LIBRARY criterion)
+
+mark_as_advanced(CRITERION_INCLUDE_DIR)
+
+# Criterion does not define the version number anywhere.
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(Criterion DEFAULT_MSG CRITERION_LIB CRITERION_INC)
+find_package_handle_standard_args(Criterion DEFAULT_MSG CRITERION_LIBRARY CRITERION_INCLUDE_DIR)
 
-if (CRITERION_FOUND AND NOT TARGET Criterion)
-  add_library(Criterion INTERFACE IMPORTED)
+if(CRITERION_FOUND)
+  set(CRITERION_INCLUDE_DIRS ${CRITERION_INCLUDE_DIR})
+  set(CRITERION_LIBRARIES ${CRITERION_LIBRARY})
 
-  set_property(TARGET Criterion PROPERTY INTERFACE_LINK_LIBRARIES "${CRITERION_LIB}")
-  set_property(TARGET Criterion PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${CRITERION_INC}")
+  if(WIN32)
+    get_filename_component(CRITERION_LIBRARY_DIR "${CRITERION_LIBRARY}}" PATH)
+    get_filename_component(CRITERION_BASENAME "${CRITERION_LIBRARY}}" NAME_WE)
+    get_filename_component(CRITERION_PREFIX "${CRITERION_LIBRARY_DIR}" PATH)
+
+    find_program(
+      CRITERION_DLL
+        "${CMAKE_SHARED_LIBRARY_PREFIX}${CRITERION_BASENAME}${CMAKE_SHARED_LIBRARY_SUFFIX}"
+      HINTS
+        ${CRITERION_PREFIX}
+      PATH_SUFFIXES
+        bin
+      NO_DEFAULT_PATH)
+    mark_as_advanced(CRITERION_DLL)
+
+    if(CRITERION_DLL)
+      add_library(Criterion SHARED IMPORTED)
+      set_target_properties(
+        Criterion PROPERTIES IMPORTED_IMPLIB "${CRITERION_LIBRARY}")
+      set_target_properties(
+        Criterion PROPERTIES IMPORTED_LOCATION "${CRITERION_DLL}")
+    else()
+      add_library(Criterion STATIC IMPORTED)
+      set_target_properties(
+        Criterion PROPERTIES IMPORTED_LOCATION "${CRITERION_LIBRARY}")
+    endif()
+  else()
+    add_library(Criterion UNKNOWN IMPORTED)
+    set_target_properties(
+      Criterion PROPERTIES IMPORTED_LOCATION "${CRITERION_LIBRARY}")
+  endif()
+
+  set_target_properties(
+    Criterion PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${CRITERION_INCLUDE_DIR}")
 endif()
 

--- a/src/core/ddsc/tests/CMakeLists.txt
+++ b/src/core/ddsc/tests/CMakeLists.txt
@@ -20,14 +20,18 @@ target_include_directories(criterion_ddsc PRIVATE
 target_link_libraries(criterion_ddsc RoundTrip Space TypesArrayKey ddsc OSAPI)
 
 # Setup environment for config-tests
-get_test_property(Criterion_ddsc_config_simple_udp ENVIRONMENT ENVIRON)
-set(CONFIG_FILE "${CMAKE_CURRENT_LIST_DIR}/config_simple_udp.xml")
-set(ENVIRON "${CMAKE_PROJECT_NAME_CAPS}_URI=file://${CONFIG_FILE};MAX_PARTICIPANTS=0;${ENVIRON}")
+get_test_property(Criterion_ddsc_config_simple_udp ENVIRONMENT Criterion_ddsc_config_simple_udp_env)
+set(Criterion_ddsc_config_simple_udp_file "${CMAKE_CURRENT_LIST_DIR}/config_simple_udp.xml")
+set(Criterion_ddsc_config_simple_udp_uri "file://${Criterion_ddsc_config_simple_udp_file}")
+set(Criterion_ddsc_config_simple_udp_max_participants "0")
+set(Criterion_ddsc_config_simple_udp_env "${CMAKE_PROJECT_NAME_CAPS}_URI=${Criterion_ddsc_config_simple_udp_uri};MAX_PARTICIPANTS=${Criterion_ddsc_config_simple_udp_max_participants};${Criterion_ddsc_config_simple_udp_env}")
+
+message(STATUS "ENV: ${Criterion_ddsc_config_simple_udp_env}")
 
 set_tests_properties(
 	Criterion_ddsc_config_simple_udp
 	PROPERTIES
-		REQUIRED_FILES ${CONFIG_FILE}
-		ENVIRONMENT "${ENVIRON}")
+		REQUIRED_FILES ${Criterion_ddsc_config_simple_udp_file}
+		ENVIRONMENT "${Criterion_ddsc_config_simple_udp_env}")
 
 configure_file("config_env.h.in" "config_env.h")

--- a/src/core/ddsc/tests/CMakeLists.txt
+++ b/src/core/ddsc/tests/CMakeLists.txt
@@ -24,8 +24,6 @@ get_test_property(Criterion_ddsc_config_simple_udp ENVIRONMENT ENVIRON)
 set(CONFIG_FILE "${CMAKE_CURRENT_LIST_DIR}/config_simple_udp.xml")
 set(ENVIRON "${CMAKE_PROJECT_NAME_CAPS}_URI=file://${CONFIG_FILE};MAX_PARTICIPANTS=0;${ENVIRON}")
 
-message(STATUS "Environment for Criterion_ddsc_config_simple_udp: ${ENVIRON}")
-
 set_tests_properties(
 	Criterion_ddsc_config_simple_udp
 	PROPERTIES

--- a/src/core/ddsc/tests/CMakeLists.txt
+++ b/src/core/ddsc/tests/CMakeLists.txt
@@ -19,15 +19,28 @@ target_include_directories(criterion_ddsc PRIVATE
 		"$<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/src/include/>")
 target_link_libraries(criterion_ddsc RoundTrip Space TypesArrayKey ddsc OSAPI)
 
+if(WIN32)
+# FIXME: Is this a valid unit test?!
+get_target_property(CRITERION_LIBRARY_TYPE Criterion TYPE)
+get_target_property(CRITERION_IMPORTED_LOCATION Criterion IMPORTED_LOCATION)
+get_filename_component(CRITERION_LIBRARY_DIR "${CRITERION_IMPORTED_LOCATION}" PATH)
+endif()
+
 # Setup environment for config-tests
 set(Criterion_ddsc_config_simple_udp_file "${CMAKE_CURRENT_LIST_DIR}/config_simple_udp.xml")
 set(Criterion_ddsc_config_simple_udp_uri "file://${Criterion_ddsc_config_simple_udp_file}")
 set(Criterion_ddsc_config_simple_udp_max_participants "0")
+if(WIN32)
 set_tests_properties(
 	Criterion_ddsc_config_simple_udp
 	PROPERTIES
 		REQUIRED_FILES ${Criterion_ddsc_config_simple_udp_file}
-		ENVIRONMENT "${CMAKE_PROJECT_NAME_CAPS}_URI=${Criterion_ddsc_config_simple_udp_uri};MAX_PARTICIPANTS=${Criterion_ddsc_config_simple_udp_max_participants}"
-
-)
+		ENVIRONMENT "${CMAKE_PROJECT_NAME_CAPS}_URI=${Criterion_ddsc_config_simple_udp_uri};MAX_PARTICIPANTS=${Criterion_ddsc_config_simple_udp_max_participants};PATH=${CRITERION_LIBRARY_DIR};$ENV{PATH}")
+else()
+set_tests_properties(
+	Criterion_ddsc_config_simple_udp
+	PROPERTIES
+		REQUIRED_FILES ${Criterion_ddsc_config_simple_udp_file}
+		ENVIRONMENT "${CMAKE_PROJECT_NAME_CAPS}_URI=${Criterion_ddsc_config_simple_udp_uri};MAX_PARTICIPANTS=${Criterion_ddsc_config_simple_udp_max_participants}")
+endif()
 configure_file("config_env.h.in" "config_env.h")

--- a/src/core/ddsc/tests/CMakeLists.txt
+++ b/src/core/ddsc/tests/CMakeLists.txt
@@ -19,28 +19,17 @@ target_include_directories(criterion_ddsc PRIVATE
 		"$<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/src/include/>")
 target_link_libraries(criterion_ddsc RoundTrip Space TypesArrayKey ddsc OSAPI)
 
-if(WIN32)
-# FIXME: Is this a valid unit test?!
-get_target_property(CRITERION_LIBRARY_TYPE Criterion TYPE)
-get_target_property(CRITERION_IMPORTED_LOCATION Criterion IMPORTED_LOCATION)
-get_filename_component(CRITERION_LIBRARY_DIR "${CRITERION_IMPORTED_LOCATION}" PATH)
-endif()
-
 # Setup environment for config-tests
-set(Criterion_ddsc_config_simple_udp_file "${CMAKE_CURRENT_LIST_DIR}/config_simple_udp.xml")
-set(Criterion_ddsc_config_simple_udp_uri "file://${Criterion_ddsc_config_simple_udp_file}")
-set(Criterion_ddsc_config_simple_udp_max_participants "0")
-if(WIN32)
+get_test_property(Criterion_ddsc_config_simple_udp ENVIRONMENT ENVIRON)
+set(CONFIG_FILE "${CMAKE_CURRENT_LIST_DIR}/config_simple_udp.xml")
+set(ENVIRON "${CMAKE_PROJECT_NAME_CAPS}_URI=file://${CONFIG_FILE};MAX_PARTICIPANTS=0;${ENVIRON}")
+
+message(STATUS "Environment for Criterion_ddsc_config_simple_udp: ${ENVIRON}")
+
 set_tests_properties(
 	Criterion_ddsc_config_simple_udp
 	PROPERTIES
-		REQUIRED_FILES ${Criterion_ddsc_config_simple_udp_file}
-		ENVIRONMENT "${CMAKE_PROJECT_NAME_CAPS}_URI=${Criterion_ddsc_config_simple_udp_uri};MAX_PARTICIPANTS=${Criterion_ddsc_config_simple_udp_max_participants};PATH=${CRITERION_LIBRARY_DIR};$ENV{PATH}")
-else()
-set_tests_properties(
-	Criterion_ddsc_config_simple_udp
-	PROPERTIES
-		REQUIRED_FILES ${Criterion_ddsc_config_simple_udp_file}
-		ENVIRONMENT "${CMAKE_PROJECT_NAME_CAPS}_URI=${Criterion_ddsc_config_simple_udp_uri};MAX_PARTICIPANTS=${Criterion_ddsc_config_simple_udp_max_participants}")
-endif()
+		REQUIRED_FILES ${CONFIG_FILE}
+		ENVIRONMENT "${ENVIRON}")
+
 configure_file("config_env.h.in" "config_env.h")

--- a/src/os/src/os_report.c
+++ b/src/os/src/os_report.c
@@ -426,6 +426,9 @@ void os_reportExit(void)
 {
     char *name;
     os_reportStack reports;
+    if (!inited) {
+        return;
+    }
 
     reports = os_threadMemGet(OS_THREAD_REPORT_STACK);
     if (reports) {


### PR DESCRIPTION
The changes in this pull request enable automated builds with Travis CI (Debug and Release with GCC 8 and Clang 6.0 on Linux and Debug and Release with Xcode 9.4 on macOS) and AppVeyor (Debug and Release for Microsoft Visual Studio 2015 and Microsoft Visual Studio 2017 on Windows 32-bit and 64-bit).

Build dependencies (specifically CUnit and Criterion) are managed with Conan so that the build process is the same across platforms. The Conan recipes are kept in git repositories maintained by ADLINK ATO and can be found on [GitHub](https://github.com/atolab). The resulting binaries are published to a [Bintray](https://bintray.com/atolab/public-conan) repository, also maintained by ADLINK ATO. Note that users can also benefit from the dependencies being managed with Conan as it saves them from having to install all of them by hand.

Some tests still fail on certain platforms, no coverage or static analysis builds are available yet and GitHub integration may not be perfect, but I think this will serve as an excellent base for qualifying future work done on cyclonedds.