### PR TITLE
Performance improvements (and a few odds and ends)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,6 +11,17 @@
 #
 cmake_minimum_required(VERSION 3.6)
 
+# Set a default build type if none was specified
+set(default_build_type "RelWithDebInfo")
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
+  set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE
+      STRING "Choose the type of build." FORCE)
+  # Set the possible values of build type for cmake-gui
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+    "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
+
 FUNCTION(PREPEND var prefix)
    SET(listVar "")
    FOREACH(f ${ARGN})

--- a/src/core/ddsc/src/dds_init.c
+++ b/src/core/ddsc/src/dds_init.c
@@ -217,7 +217,6 @@ extern void dds_fini (void)
 
 static int dds__init_plugin (void)
 {
-  os_mutexInit (&gv.attach_lock);
   dds_iid_init ();
   if (dds_global.m_dur_init) (dds_global.m_dur_init) ();
   return 0;
@@ -225,7 +224,6 @@ static int dds__init_plugin (void)
 
 static void dds__fini_plugin (void)
 {
-  os_mutexDestroy (&gv.attach_lock);
   if (dds_global.m_dur_fini) (dds_global.m_dur_fini) ();
   dds_iid_fini ();
 }

--- a/src/core/ddsc/src/dds_writer.c
+++ b/src/core/ddsc/src/dds_writer.c
@@ -417,7 +417,7 @@ dds_create_writer(
     dds_entity_t publisher;
     struct thread_state1 * const thr = lookup_thread_state();
     const bool asleep = !vtime_awake_p(thr->vtime);
-    ddsi_tran_conn_t conn = gv.data_conn_mc ? gv.data_conn_mc : gv.data_conn_uc;
+    ddsi_tran_conn_t conn = gv.data_conn_uc;
     dds_return_t ret;
 
     DDS_REPORT_STACK();

--- a/src/core/ddsi/include/ddsi/q_config.h
+++ b/src/core/ddsi/include/ddsi/q_config.h
@@ -260,6 +260,8 @@ struct config
   int noprogress_log_stacktraces;
   int prioritize_retransmit;
   int xpack_send_async;
+  int multiple_recv_threads;
+  unsigned recv_thread_stop_maxretries;
 
   unsigned primary_reorder_maxsamples;
   unsigned secondary_reorder_maxsamples;

--- a/src/core/ddsi/include/ddsi/q_globals.h
+++ b/src/core/ddsi/include/ddsi/q_globals.h
@@ -190,11 +190,6 @@ struct q_globals {
 
   os_mutex lock;
 
-  /* guarantees serialisation of attach/detach operations on waitsets
-     -- a single global lock is a bit coarse, but these operations are
-     rare and at initialisation time anyway */
-  os_mutex attach_lock;
-
   /* Receive thread. (We can only has one for now, cos of the signal
      trigger socket.) Receive buffer pool is per receive thread,
      practical considerations led to it being a global variable

--- a/src/core/ddsi/include/ddsi/q_receive.h
+++ b/src/core/ddsi/include/ddsi/q_receive.h
@@ -20,8 +20,10 @@ struct nn_rbufpool;
 struct nn_rsample_info;
 struct nn_rdata;
 struct ddsi_tran_listener;
+struct recv_thread_arg;
 
-uint32_t recv_thread (struct nn_rbufpool *rbpool);
+void trigger_recv_threads (void);
+uint32_t recv_thread (void *vrecv_thread_arg);
 uint32_t listen_thread (struct ddsi_tran_listener * listener);
 int user_dqueue_handler (const struct nn_rsample_info *sampleinfo, const struct nn_rdata *fragchain, const nn_guid_t *rdguid, void *qarg);
 

--- a/src/core/ddsi/include/ddsi/q_rtps.h
+++ b/src/core/ddsi/include/ddsi/q_rtps.h
@@ -80,7 +80,6 @@ int rtps_config_prep (struct cfgst *cfgst);
 int rtps_config_open (void);
 int rtps_init (void);
 void ddsi_plugin_init (void);
-void rtps_term_prep (void);
 void rtps_term (void);
 
 #if defined (__cplusplus)

--- a/src/core/ddsi/include/ddsi/q_sockwaitset.h
+++ b/src/core/ddsi/include/ddsi/q_sockwaitset.h
@@ -62,8 +62,10 @@ void os_sockWaitsetTrigger (os_sockWaitset ws);
 
   Closing a connection associated with a waitset is handled gracefully: no
   operations will signal errors because of it.
+
+  Returns < 0 on error, 0 if already present, 1 if added
 */
-void os_sockWaitsetAdd (os_sockWaitset ws, struct ddsi_tran_conn * conn);
+int os_sockWaitsetAdd (os_sockWaitset ws, struct ddsi_tran_conn * conn);
 
 /*
   Drops all connections from the waitset from index onwards. Index

--- a/src/core/ddsi/src/ddsi_tcp.c
+++ b/src/core/ddsi/src/ddsi_tcp.c
@@ -263,8 +263,11 @@ static void ddsi_tcp_conn_connect (ddsi_tcp_conn_t conn, const struct msghdr * m
     /* Also may need to receive on connection so add to waitset */
 
     os_sockSetNonBlocking (conn->m_sock, true);
-    os_sockWaitsetAdd (gv.waitset, &conn->m_base);
-    os_sockWaitsetTrigger (gv.waitset);
+
+    assert (gv.n_recv_threads > 0);
+    assert (gv.recv_threads[0].arg.mode == RTM_MANY);
+    os_sockWaitsetAdd (gv.recv_threads[0].arg.u.many.ws, &conn->m_base);
+    os_sockWaitsetTrigger (gv.recv_threads[0].arg.u.many.ws);
   }
 }
 

--- a/src/core/ddsi/src/ddsi_tran.c
+++ b/src/core/ddsi/src/ddsi_tran.c
@@ -247,13 +247,13 @@ int ddsi_is_mcaddr (const nn_locator_t *loc)
 {
   /* FIXME: should set m_is_mcaddr_fn to a function returning false if transport doesn't provide an implementation, and get rid of the test */
   ddsi_tran_factory_t tran = ddsi_factory_find_supported_kind(loc->kind);
-  return tran->m_is_mcaddr_fn ? tran->m_is_mcaddr_fn (tran, loc) : 0;
+  return tran && tran->m_is_mcaddr_fn ? tran->m_is_mcaddr_fn (tran, loc) : 0;
 }
 
 int ddsi_is_ssm_mcaddr (const nn_locator_t *loc)
 {
   ddsi_tran_factory_t tran = ddsi_factory_find_supported_kind(loc->kind);
-  return tran->m_is_ssm_mcaddr_fn ? tran->m_is_ssm_mcaddr_fn (tran, loc) : 0;
+  return tran && tran->m_is_ssm_mcaddr_fn ? tran->m_is_ssm_mcaddr_fn (tran, loc) : 0;
 }
 
 enum ddsi_nearby_address_result ddsi_is_nearby_address (const nn_locator_t *loc, size_t ninterf, const struct nn_interface interf[])

--- a/src/core/ddsi/src/ddsi_tran.c
+++ b/src/core/ddsi/src/ddsi_tran.c
@@ -47,9 +47,8 @@ void ddsi_tran_factories_fini (void)
     ddsi_tran_factory_t factory;
 
     while ((factory = ddsi_tran_factories) != NULL) {
-        ddsi_tran_factories = ddsi_tran_factories->m_factory;
-
         ddsi_factory_free(factory);
+        ddsi_tran_factories = ddsi_tran_factories->m_factory;
     }
 }
 
@@ -97,6 +96,9 @@ void ddsi_conn_free (ddsi_tran_conn_t conn)
     if (! conn->m_closed)
     {
       conn->m_closed = true;
+      /* FIXME: rethink the socket waitset & the deleting of entries; the biggest issue is TCP handling that can open & close sockets at will and yet expects the waitset to wake up at the apprioriate times.  (This pretty much works with the select-based version, but not the kqueue-based one.)  TCP code can also have connections without a socket ...  Calling sockWaitsetRemove here (where there shouldn't be any knowledge of it) at least ensures that it is removed in time and that there can't be aliasing of connections and sockets.   */
+      if (ddsi_conn_handle (conn) != Q_INVALID_SOCKET)
+        os_sockWaitsetRemove (gv.waitset, conn);
       if (conn->m_factory->m_close_conn_fn)
       {
         (conn->m_factory->m_close_conn_fn) (conn);

--- a/src/core/ddsi/src/ddsi_tran.c
+++ b/src/core/ddsi/src/ddsi_tran.c
@@ -98,7 +98,27 @@ void ddsi_conn_free (ddsi_tran_conn_t conn)
       conn->m_closed = true;
       /* FIXME: rethink the socket waitset & the deleting of entries; the biggest issue is TCP handling that can open & close sockets at will and yet expects the waitset to wake up at the apprioriate times.  (This pretty much works with the select-based version, but not the kqueue-based one.)  TCP code can also have connections without a socket ...  Calling sockWaitsetRemove here (where there shouldn't be any knowledge of it) at least ensures that it is removed in time and that there can't be aliasing of connections and sockets.   */
       if (ddsi_conn_handle (conn) != Q_INVALID_SOCKET)
-        os_sockWaitsetRemove (gv.waitset, conn);
+      {
+        unsigned i;
+        for (i = 0; i < gv.n_recv_threads; i++)
+        {
+          if (!gv.recv_threads[i].ts)
+            assert (!gv.rtps_keepgoing);
+          else
+          {
+            switch (gv.recv_threads[i].arg.mode)
+            {
+              case RTM_MANY:
+                os_sockWaitsetRemove (gv.recv_threads[i].arg.u.many.ws, conn);
+                break;
+              case RTM_SINGLE:
+                if (gv.recv_threads[i].arg.u.single.conn == conn)
+                  abort();
+                break;
+            }
+          }
+        }
+      }
       if (conn->m_factory->m_close_conn_fn)
       {
         (conn->m_factory->m_close_conn_fn) (conn);

--- a/src/core/ddsi/src/ddsi_udp.c
+++ b/src/core/ddsi/src/ddsi_udp.c
@@ -59,12 +59,17 @@ static ssize_t ddsi_udp_conn_read (ddsi_tran_conn_t conn, unsigned char * buf, s
   msg_iov.iov_base = (void*) buf;
   msg_iov.iov_len = (ddsi_iov_len_t)len; /* windows uses unsigned, POISX size_t */
 
-  memset (&msghdr, 0, sizeof (msghdr));
-
   msghdr.msg_name = &src;
   msghdr.msg_namelen = srclen;
   msghdr.msg_iov = &msg_iov;
   msghdr.msg_iovlen = 1;
+#if !defined(__sun) || defined(_XPG4_2)
+  msghdr.msg_control = NULL;
+  msghdr.msg_controllen = 0;
+#else
+  msghdr.msg_accrights = NULL;
+  msghdr.msg_accrightslen = 0;
+#endif
 
   do {
     ret = recvmsg(((ddsi_udp_conn_t) conn)->m_sock, &msghdr, 0);
@@ -113,10 +118,16 @@ static ssize_t ddsi_udp_conn_write (ddsi_tran_conn_t conn, const nn_locator_t *d
   os_sockaddr_storage dstaddr;
   assert(niov <= INT_MAX);
   ddsi_ipaddr_from_loc(&dstaddr, dst);
-  memset(&msg, 0, sizeof(msg));
   set_msghdr_iov (&msg, (ddsi_iovec_t *) iov, niov);
   msg.msg_name = &dstaddr;
   msg.msg_namelen = (socklen_t) os_sockaddrSizeof((os_sockaddr *) &dstaddr);
+#if !defined(__sun) || defined(_XPG4_2)
+  msg.msg_control = NULL;
+  msg.msg_controllen = 0;
+#else
+  msg.msg_accrights = NULL;
+  msg.msg_accrightslen = 0;
+#endif
 #if SYSDEPS_MSGHDR_FLAGS
   msg.msg_flags = (int) flags;
 #endif

--- a/src/core/ddsi/src/q_config.c
+++ b/src/core/ddsi/src/q_config.c
@@ -505,6 +505,12 @@ static const struct cfgelem liveliness_monitoring_attrs[] = {
   END_MARKER
 };
 
+static const struct cfgelem multiple_recv_threads_attrs[] = {
+  { ATTR("maxretries"), 1, "4294967295", ABSOFF(recv_thread_stop_maxretries), 0, uf_uint, 0, pf_uint,
+    "<p>Receive threads dedicated to a single socket can only be triggered for termination by sending a packet. Reception of any packet will do, so termination failure due to packet loss is exceedingly unlikely, but to eliminate all risks, it will retry as many times as specified by this attribute before aborting.</p>" },
+  END_MARKER
+};
+
 static const struct cfgelem unsupp_cfgelems[] = {
     { MOVED("MaxMessageSize", "General/MaxMessageSize") },
     { MOVED("FragmentSize", "General/FragmentSize") },
@@ -614,6 +620,8 @@ static const struct cfgelem unsupp_cfgelems[] = {
 "<p>This element controls whether the actual sending of packets occurs on the same thread that prepares them, or is done asynchronously by another thread.</p>" },
 { LEAF_W_ATTRS("RediscoveryBlacklistDuration", rediscovery_blacklist_duration_attrs), 1, "10s", ABSOFF(prune_deleted_ppant.delay), 0, uf_duration_inf, 0, pf_duration,
 "<p>This element controls for how long a remote participant that was previously deleted will remain on a blacklist to prevent rediscovery, giving the software on a node time to perform any cleanup actions it needs to do. To some extent this delay is required internally by DDSI2E, but in the default configuration with the 'enforce' attribute set to false, DDSI2E will reallow rediscovery as soon as it has cleared its internal administration. Setting it to too small a value may result in the entry being pruned from the blacklist before DDSI2E is ready, it is therefore recommended to set it to at least several seconds.</p>" },
+  { LEAF_W_ATTRS("MultipleReceiveThreads", multiple_recv_threads_attrs), 1, "true", ABSOFF(multiple_recv_threads), 0, uf_boolean, 0, pf_boolean,
+         "<p>This element controls whether all traffic is handled by a single receive thread or whether multiple receive threads may be used to improve latency. Currently multiple receive threads are only used for connectionless transport (e.g., UDP) and ManySocketsMode not set to single (the default).</p>" },
 { MGROUP("ControlTopic", control_topic_cfgelems, control_topic_cfgattrs), 1, 0, 0, 0, 0, 0, 0, 0,
 "<p>The ControlTopic element allows configured whether DDSI2E provides a special control interface via a predefined topic or not.<p>" },
 { GROUP("Test", unsupp_test_cfgelems),

--- a/src/core/ddsi/src/q_config.c
+++ b/src/core/ddsi/src/q_config.c
@@ -2927,7 +2927,7 @@ void config_fini(_In_ struct cfgst *cfgst)
     assert(config.valid);
 
     free_all_elements(cfgst, cfgst->cfg, root_cfgelems);
-    if ( config.tracingOutputFile ) {
+    if ( config.tracingOutputFile && config.tracingOutputFile != stdout && config.tracingOutputFile != stderr) {
         fclose(config.tracingOutputFile);
     }
     memset(&config, 0, sizeof(config));

--- a/src/core/ddsi/src/q_entity.c
+++ b/src/core/ddsi/src/q_entity.c
@@ -39,6 +39,7 @@
 #include "ddsi/q_builtin_topic.h"
 #include "ddsi/ddsi_ser.h"
 #include "ddsi/ddsi_mcgroup.h"
+#include "ddsi/q_receive.h"
 
 #include "ddsi/sysdeps.h"
 #include "dds__whc.h"
@@ -575,7 +576,7 @@ int new_participant_guid (const nn_guid_t *ppguid, unsigned flags, const nn_plis
   {
     os_atomic_fence ();
     os_atomic_inc32 (&gv.participant_set_generation);
-    os_sockWaitsetTrigger (gv.waitset);
+    trigger_recv_threads ();
   }
 
   /* SPDP periodic broadcast uses the retransmit path, so the initial
@@ -784,7 +785,6 @@ static void unref_participant (struct participant *pp, const struct nn_guid *gui
       /* Deleting the socket will usually suffice to wake up the
          receiver threads, but in general, no one cares if it takes a
          while longer for it to wakeup. */
-
       ddsi_conn_free (pp->m_conn);
     }
     nn_plist_fini (pp->plist);

--- a/src/core/ddsi/src/q_init.c
+++ b/src/core/ddsi/src/q_init.c
@@ -1516,4 +1516,5 @@ OS_WARNING_MSVC_ON(6001);
   ddsi_serstatepool_free (gv.serpool);
   nn_xmsgpool_free (gv.xmsgpool);
   (ddsi_plugin.fini_fn) ();
+  nn_log (LC_CONFIG, "Finis.\n");
 }

--- a/src/core/ddsi/src/q_init.c
+++ b/src/core/ddsi/src/q_init.c
@@ -924,15 +924,9 @@ int rtps_init (void)
   }
   if (config.allowMulticast)
   {
-    int i;
-    for (i = 0; i < gv.n_interfaces; i++)
+    if (!gv.interfaces[gv.selected_interface].mc_capable)
     {
-      if (gv.interfaces[i].mc_capable)
-        break;
-    }
-    if (i == gv.n_interfaces)
-    {
-      NN_WARNING ("No multicast capable interfaces: disabling multicast\n");
+      NN_WARNING ("selected interface is not multicast-capable: disabling multicast\n");
       config.suppress_spdp_multicast = 1;
       config.allowMulticast = AMC_FALSE;
     }

--- a/src/core/ddsi/src/q_init.c
+++ b/src/core/ddsi/src/q_init.c
@@ -1440,8 +1440,6 @@ void rtps_term (void)
 
   ut_thread_pool_free (gv.thread_pool);
 
-  os_sockWaitsetFree (gv.waitset);
-
   (void) joinleave_spdp_defmcip (0);
 
   ddsi_conn_free (gv.disc_conn_mc);
@@ -1460,6 +1458,7 @@ void rtps_term (void)
 
   free_group_membership(gv.mship);
   ddsi_tran_factories_fini ();
+  os_sockWaitsetFree (gv.waitset);
 
   if (gv.pcap_fp)
   {

--- a/src/core/ddsi/src/q_servicelease.c
+++ b/src/core/ddsi/src/q_servicelease.c
@@ -21,6 +21,7 @@
 #include "ddsi/q_unused.h"
 #include "ddsi/q_error.h"
 #include "ddsi/q_globals.h" /* for mattr, cattr */
+#include "ddsi/q_receive.h"
 
 #include "ddsi/sysdeps.h" /* for getrusage() */
 
@@ -172,9 +173,7 @@ static uint32_t lease_renewal_thread (struct nn_servicelease *sl)
        every now and then to try recreating sockets & rejoining multicast
        groups */
     if (gv.deaf)
-    {
-      os_sockWaitsetTrigger(gv.waitset);
-    }
+      trigger_recv_threads ();
   }
   os_mutexUnlock (&sl->lock);
   return 0;

--- a/src/core/ddsi/src/q_xevent.c
+++ b/src/core/ddsi/src/q_xevent.c
@@ -984,7 +984,7 @@ static void handle_xevk_spdp (UNUSED_ARG (struct nn_xpack *xp), struct xevent *e
   {
     TRACE (("handle_xevk_spdp %x:%x:%x:%x - spdp writer of participant not found\n",
             PGUID (ev->u.spdp.pp_guid)));
-    goto skip;
+    return;
   }
 
   if (!ev->u.spdp.directed)

--- a/src/examples/roundtrip/ping.c
+++ b/src/examples/roundtrip/ping.c
@@ -13,7 +13,7 @@
 /* Forward declaration */
 
 static dds_entity_t prepare_dds(dds_entity_t *writer, dds_entity_t *reader, dds_entity_t *readCond, dds_listener_t *listener);
-static void finalize_dds(dds_entity_t participant, dds_entity_t reader, dds_entity_t readCond);
+static void finalize_dds(dds_entity_t participant);
 
 typedef struct ExampleTimeStats
 {
@@ -402,7 +402,7 @@ done:
   sigaction (SIGINT, &oldAction, 0);
 #endif
 
-  finalize_dds(participant, reader, readCond);
+  finalize_dds(participant);
 
   /* Clean up */
   exampleDeleteTimeStats (&roundTrip);
@@ -484,19 +484,9 @@ static dds_entity_t prepare_dds(dds_entity_t *wr, dds_entity_t *rd, dds_entity_t
   return participant;
 }
 
-static void finalize_dds(dds_entity_t ppant, dds_entity_t rd, dds_entity_t rdcond)
+static void finalize_dds(dds_entity_t ppant)
 {
   dds_return_t status;
-
-  /* Disable callbacks */
-  dds_set_enabled_status (rd, 0);
-
-  (void) dds_waitset_detach (waitSet, rdcond);
-  status = dds_waitset_detach (waitSet, waitSet);
-  DDS_ERR_CHECK (status, DDS_CHECK_REPORT | DDS_CHECK_EXIT);
-  (void) dds_delete (rdcond);
-  status = dds_delete (waitSet);
-  DDS_ERR_CHECK (status, DDS_CHECK_REPORT | DDS_CHECK_EXIT);
   status = dds_delete (ppant);
   DDS_ERR_CHECK (status, DDS_CHECK_REPORT | DDS_CHECK_EXIT);
 }

--- a/src/examples/roundtrip/ping.c
+++ b/src/examples/roundtrip/ping.c
@@ -182,10 +182,10 @@ static void data_available(dds_entity_t rd, void *arg)
       printf("%9" PRIi64 " %9lu %8.0f %8" PRIi64 " %8" PRIi64 " %8" PRIi64 " %10lu %8.0f %8" PRIi64 " %10lu %8.0f %8" PRIi64 "\n",
              elapsed + 1,
              roundTrip.count,
-             exampleGetMedianFromTimeStats (&roundTrip),
-             roundTrip.min,
-             exampleGet99PercentileFromTimeStats (&roundTrip),
-             roundTrip.max,
+             exampleGetMedianFromTimeStats (&roundTrip) / 2,
+             roundTrip.min / 2,
+             exampleGet99PercentileFromTimeStats (&roundTrip) / 2,
+             roundTrip.max / 2,
              writeAccess.count,
              exampleGetMedianFromTimeStats (&writeAccess),
              writeAccess.min,
@@ -352,8 +352,8 @@ int main (int argc, char *argv[])
     warmUp = false;
     printf("# Warm up complete.\n\n");
 
-    printf("# Round trip measurements (in us)\n");
-    printf("#             Round trip time [us]                           Write-access time [us]       Read-access time [us]\n");
+    printf("# Latency measurements (in us)\n");
+    printf("#             Latency [us]                                   Write-access time [us]       Read-access time [us]\n");
     printf("# Seconds     Count   median      min      99%%      max      Count   median      min      Count   median      min\n");
 
   }
@@ -380,11 +380,13 @@ int main (int argc, char *argv[])
   {
     printf
     (
-      "\n%9s %9lu %8.0f %8" PRIi64 " %10lu %8.0f %8" PRIi64 " %10lu %8.0f %8" PRIi64 "\n",
+      "\n%9s %9lu %8.0f %8" PRIi64 " %8" PRIi64 " %8" PRIi64 " %10lu %8.0f %8" PRIi64 " %10lu %8.0f %8" PRIi64 "\n",
       "# Overall",
       roundTripOverall.count,
-      exampleGetMedianFromTimeStats (&roundTripOverall),
-      roundTripOverall.min,
+      exampleGetMedianFromTimeStats (&roundTripOverall) / 2,
+      roundTripOverall.min / 2,
+      exampleGet99PercentileFromTimeStats (&roundTripOverall) / 2,
+      roundTripOverall.max / 2,
       writeAccessOverall.count,
       exampleGetMedianFromTimeStats (&writeAccessOverall),
       writeAccessOverall.min,

--- a/src/examples/roundtrip/pong.c
+++ b/src/examples/roundtrip/pong.c
@@ -11,7 +11,7 @@ static dds_entity_t waitSet;
 
 /* Forward declarations */
 static dds_entity_t prepare_dds(dds_entity_t *writer, dds_entity_t *reader, dds_entity_t *readCond, dds_listener_t *listener);
-static void finalize_dds(dds_entity_t participant, dds_entity_t readCond, RoundTripModule_DataType data[MAX_SAMPLES]);
+static void finalize_dds(dds_entity_t participant, RoundTripModule_DataType data[MAX_SAMPLES]);
 
 #ifdef _WIN32
 #include <Windows.h>
@@ -131,23 +131,16 @@ int main (int argc, char *argv[])
 #endif
 
   /* Clean up */
-  finalize_dds(participant, readCond, data);
+  finalize_dds(participant, data);
 
   return EXIT_SUCCESS;
 }
 
-static void finalize_dds(dds_entity_t participant, dds_entity_t readCond, RoundTripModule_DataType data[MAX_SAMPLES])
+static void finalize_dds(dds_entity_t participant, RoundTripModule_DataType data[MAX_SAMPLES])
 {
   dds_return_t status;
-  (void)dds_waitset_detach (waitSet, readCond);
-  status = dds_waitset_detach (waitSet, waitSet);
-  DDS_ERR_CHECK (status, DDS_CHECK_REPORT | DDS_CHECK_EXIT);
-  (void)dds_delete (readCond);
-  status = dds_delete (waitSet);
-  DDS_ERR_CHECK (status, DDS_CHECK_REPORT | DDS_CHECK_EXIT);
   status = dds_delete (participant);
   DDS_ERR_CHECK (status, DDS_CHECK_REPORT | DDS_CHECK_EXIT);
-
   for (unsigned int i = 0; i < MAX_SAMPLES; i++)
   {
     RoundTripModule_DataType_free (&data[i], DDS_FREE_CONTENTS);


### PR DESCRIPTION
This pull request primarily changes the way network input is handled:

- It adds support for having multiple receive threads, such that receive threads handling a single socket avoid input multiplexing. This has a shockingly large effect on macOS, and a small effect on Linux.
- On macOS it now does input multiplexing using a kqueue instead of `select` because a kqueue is much faster.

These improvements show up as lower latencies in ping-pong tests and as less system time spent for handling incoming packets.

There are some attendant changes, of course ...

- Latency measurement tool now reports one-way latencies rather than roundtrip times and adds the 99% percentile latency; and no longer tries to delete non-existent entities when terminating.
- It turns out the code for generating stack traces when some threads seem to not be making progress can't handle the case where a thread stops just when it a stack trace of it is requested (it hangs).
- Disabling multicast when the selected interface doesn't support it (mostly because it means it becomes impossible to stop single-socket receive threads on a multicast socket).
- Eliminating some superfluous small memsets save a surprising amount of time.
- It no longer closes stdout/stderr if those are used for tracing.
- It no longer keeps rescheduling sending a participant discovery message if there's no writer to use.
- It no longer uses the multicast receive socket when sending application data.
- It prints a final line in the DDSI trace ("Finis.") when everything has ended, making it trivial to check the stack shut down cleanly.
- It no longer crashes when checking whether an invalid address is a multicast address.

and finally ...

- builds now default to RelWithDebInfo if no CMAKE_BUILD_TYPE is specified. The default behaviour of cmake makes no sense whatsoever, and RelWithDebInfo is the most reasonable compromise.