### PR TITLE
More sensible domain id handling; stopping throughput publisher

### DIFF
--- a/src/core/ddsc/src/dds__init.h
+++ b/src/core/ddsc/src/dds__init.h
@@ -32,7 +32,7 @@ dds__check_domain(
  *-# Returns 0 on success or a non-zero error status
  **/
 dds_return_t
-dds_init(void);
+dds_init(dds_domainid_t domain);
 
 /* Finalization function, called from main */
 

--- a/src/core/ddsc/src/dds_builtin.c
+++ b/src/core/ddsc/src/dds_builtin.c
@@ -137,8 +137,8 @@ dds__create_builtin_participant(
     }
 
     pp->m_entity.m_guid = guid;
-    pp->m_entity.m_domain = dds_domain_create (config.domainId);
-    pp->m_entity.m_domainid = config.domainId;
+    pp->m_entity.m_domain = dds_domain_create (config.domainId.value);
+    pp->m_entity.m_domainid = config.domainId.value;
     pp->m_entity.m_deriver.delete = dds__delete_builtin_participant;
 
 fail:

--- a/src/core/ddsc/src/dds_participant.c
+++ b/src/core/ddsc/src/dds_participant.c
@@ -148,7 +148,7 @@ dds_create_participant(
     bool asleep;
 
     /* Make sure DDS instance is initialized. */
-    ret = dds_init();
+    ret = dds_init(domain);
     if (ret != DDS_RETCODE_OK) {
         e = (dds_entity_t)ret;
         goto fail_dds_init;

--- a/src/core/ddsc/tests/participant.c
+++ b/src/core/ddsc/tests/participant.c
@@ -45,13 +45,13 @@ Test(ddsc_participant, create_with_no_conf_no_env) {
   dds_entity_t participant, participant2, participant3;
   dds_return_t status;
   dds_domainid_t domain_id;
-  dds_domainid_t valid_domain=0;
+  dds_domainid_t valid_domain=3;
 
   const char * env_uri = os_getenv(DDSC_PROJECT_NAME_NOSPACE_CAPS"_URI");
   cr_assert_eq(env_uri, NULL, DDSC_PROJECT_NAME_NOSPACE_CAPS"_URI must be NULL");
 
   //invalid domain
-  participant = dds_create_participant (1, NULL, NULL);
+  participant = dds_create_participant (-2, NULL, NULL);
   cr_assert_lt(participant, 0, "Error must be received for invalid domain value");
 
   //valid specific domain value

--- a/src/core/ddsi/include/ddsi/q_config.h
+++ b/src/core/ddsi/include/ddsi/q_config.h
@@ -235,11 +235,10 @@ struct config
   enum boolean_default compat_tcp_enable;
   int dontRoute;
   int enableMulticastLoopback;
-  int domainId;
+  struct config_maybe_int32 domainId;
   int participantIndex;
   int maxAutoParticipantIndex;
   int port_base;
-  struct config_maybe_int32 discoveryDomainId;
   char *spdpMulticastAddressString;
   char *defaultMulticastAddressString;
   char *assumeMulticastCapable;

--- a/src/core/ddsi/src/q_addrset.c
+++ b/src/core/ddsi/src/q_addrset.c
@@ -101,7 +101,7 @@ static int add_addresses_to_addrset_1 (struct addrset *as, const char *ip, int p
       int i;
       for (i = 0; i <= config.maxAutoParticipantIndex; i++)
       {
-        int port = config.port_base + config.port_dg * config.domainId + i * config.port_pg + config.port_d1;
+        int port = config.port_base + config.port_dg * config.domainId.value + i * config.port_pg + config.port_d1;
         loc.port = (unsigned) port;
         if (i == 0)
           nn_log (LC_CONFIG, "%s", ddsi_locator_to_string(buf, sizeof(buf), &loc));
@@ -114,7 +114,7 @@ static int add_addresses_to_addrset_1 (struct addrset *as, const char *ip, int p
     {
       int port = port_mode;
       if (port == -1)
-        port = config.port_base + config.port_dg * config.domainId + config.port_d0;
+        port = config.port_base + config.port_dg * config.domainId.value + config.port_d0;
       loc.port = (unsigned) port;
       nn_log (LC_CONFIG, "%s", ddsi_locator_to_string(buf, sizeof(buf), &loc));
       add_to_addrset (as, &loc);

--- a/src/etc/cmake/default.xml.in
+++ b/src/etc/cmake/default.xml.in
@@ -11,7 +11,7 @@
 -->
 <@CMAKE_PROJECT_NAME@>
   <Domain>
-    <Id>0</Id>
+    <Id>any</Id>
   </Domain>
   <DDSI2E>
     <General>

--- a/src/examples/throughput/publisher.c
+++ b/src/examples/throughput/publisher.c
@@ -57,17 +57,6 @@ int main (int argc, char **argv)
   dds_entity_t writer;
   ThroughputModule_DataType sample;
 
-  /* Register handler for Ctrl-C */
-#ifdef _WIN32
-  SetConsoleCtrlHandler ((PHANDLER_ROUTINE) CtrlHandler, true);
-#else
-  struct sigaction sat;
-  sat.sa_handler = CtrlHandler;
-  sigemptyset (&sat.sa_mask);
-  sat.sa_flags = 0;
-  sigaction (SIGINT, &sat, &oldAction);
-#endif
-
   if (parse_args(argc, argv, &payloadSize, &burstInterval, &burstSize, &timeOut, &partitionName) == EXIT_FAILURE) {
     return EXIT_FAILURE;
   }
@@ -89,6 +78,17 @@ int main (int argc, char **argv)
   for (uint32_t i = 0; i < payloadSize; i++) {
     sample.payload._buffer[i] = 'a';
   }
+
+  /* Register handler for Ctrl-C */
+#ifdef _WIN32
+  SetConsoleCtrlHandler ((PHANDLER_ROUTINE) CtrlHandler, true);
+#else
+  struct sigaction sat;
+  sat.sa_handler = CtrlHandler;
+  sigemptyset (&sat.sa_mask);
+  sat.sa_flags = 0;
+  sigaction (SIGINT, &sat, &oldAction);
+#endif
 
   /* Register the sample instance and write samples repeatedly or until time out */
   start_writing(writer, &sample, burstInterval, burstSize, timeOut);


### PR DESCRIPTION
This pull request partially addresses two open issues:
* One commit addresses the first issue raised in #23, by allowing any domain id to be used in ``dds_create_participant`` as long as the configuration file doesn't explicitly set a domain id. To accomplish this, the domain id specification in the configuration file now allows the keyword ``any`` (also the new default). This doesn't affect any cases that used to work already.
* The other commit addresses the observation in #22 that ^C doesn't work when there is no subscriber. It ignores the termination flag set by the ^C handler while waiting for the subscriber to show up. This fix addresses it by delaying the setting of the handler, until the termination flag is respected.
The other points raised in these two issues are not addressed.