### PR TITLE
Use Conan recipe from Bincrafters for CUnit

### DIFF
--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-cunit/2.1-3@atolab/stable
+cunit/2.1-3@bincrafters/stable
 criterion/2.3.2@atolab/stable
 
 [generators]


### PR DESCRIPTION
Bincrafters accepted my Conan CUnit recipe. Please switch to using their recipe as it'll be maintained in [the Bincrafters conan-cunit git repository](https://github.com/bincrafters/conan-cunit) and binaries will be hosted in [the Bincrafters conan-cunit binary repository](https://bintray.com/bincrafters/public-conan/cunit%3Abincrafters/2.1-3%3Astable) from now on.